### PR TITLE
Fixed issue 97, 99 & 100

### DIFF
--- a/Assets/Code/Classes/Map System/Tile.cs
+++ b/Assets/Code/Classes/Map System/Tile.cs
@@ -254,5 +254,6 @@ public class Tile
             throw new InvalidOperationException("No event applied to this tile");
         }
         CurrentEvent = null;
+        tileObject.RemoveEventIcon();
     }
 }

--- a/Assets/Code/Classes/Map System/TileObject.cs
+++ b/Assets/Code/Classes/Map System/TileObject.cs
@@ -188,7 +188,7 @@ public class TileObject
         }
     }
 
-    // created by jbt
+    //Created by JBT
     /// <summary>
     /// Set the tiles event icon and display it
     /// </summary>
@@ -197,6 +197,15 @@ public class TileObject
     {
         tileEventDisplay.SetActive(true);
         tileEventDisplay.GetComponent<Renderer>().material.mainTexture = Resources.Load<Texture2D>(iconPath);
+    }
+
+    //Created by JBT
+    /// <summary>
+    /// Remove the random event display from a tile
+    /// </summary>
+    public void RemoveEventIcon()
+    {
+        tileEventDisplay.SetActive(false);
     }
 
     // created by jbt

--- a/Assets/Code/Scripts/GUI/canvasScript.cs
+++ b/Assets/Code/Scripts/GUI/canvasScript.cs
@@ -303,6 +303,7 @@ public class canvasScript : MonoBehaviour
     public void PurchaseTile(Tile tile)
     {
         humanGui.PurchaseTile(tile);
+        tileWindow.Refresh();
     }
 
     public void ShowTileInfoWindow(Tile tile)

--- a/Assets/Code/Scripts/GUI/canvasScript.cs
+++ b/Assets/Code/Scripts/GUI/canvasScript.cs
@@ -226,6 +226,7 @@ public class canvasScript : MonoBehaviour
     public void ShowRoboticonWindow()
     {
         roboticonList.gameObject.SetActive(true);
+        ShowRoboticonList();
     }
 
     public void HideRoboticonWindow()


### PR DESCRIPTION
## 97
Simple one line fix, purchased tiles now have the button to purchase them in the tile window removed.

## 99
Another one line fix, the roboticon window is now force refreshed when opened

## 100
When a random event ends, it's icon is now removed from any tiles it was affecting

closes #97 
closes #99
closes #100