### PR TITLE
Spelling fixes and shorter event messages

### DIFF
--- a/Assets/Code/Classes/RandomEvent.cs
+++ b/Assets/Code/Classes/RandomEvent.cs
@@ -86,7 +86,7 @@ public class RandomEvent
     /// <summary>
     /// create a new type of random event
     /// </summary>
-    /// <param name="tilte">The title of the event for display to the user</param>
+    /// <param name="title">The title of the event for display to the user</param>
     /// <param name="description">a detailed description of the event, for display to the user</param>
     /// <param name="duration">How many turns the event should last</param>
     /// <param name="numberOfTilesToAffect">how many tiles should the event affect</param>
@@ -97,9 +97,9 @@ public class RandomEvent
     /// <param name="energyMult">the multiplier that should be applied to energy production on affected tiles</param>
     /// <param name="oreMult">the multiplier that should be applied to ore production on affected tiles</param>
     /// <param name="iconPath">path to the icon to display on tiles affected by this event</param>
-    public RandomEvent(string tilte, string description, int duration, int numberOfTilesToAffect, bool connectedOnly, bool roboticonInstalled, bool noRoboticonInstalled, float foodMult, float energyMult, float oreMult, string iconPath)
+    public RandomEvent(string title, string description, int duration, int numberOfTilesToAffect, bool connectedOnly, bool roboticonInstalled, bool noRoboticonInstalled, float foodMult, float energyMult, float oreMult, string iconPath)
     {
-        if (tilte.Length == 0)
+        if (title.Length == 0)
         {
             throw new ArgumentException("title cannot be empty");
         }
@@ -124,7 +124,7 @@ public class RandomEvent
         {
             throw new ArgumentOutOfRangeException("resource multipliers cannot be < 0");
         }
-        Title = tilte;
+        Title = title;
         Description = description;
         Duration = duration;
         NumberOfTilesToAffect = numberOfTilesToAffect;

--- a/Assets/Resources/Events.json
+++ b/Assets/Resources/Events.json
@@ -2,7 +2,7 @@
 	"configurations": [
 		{
 			"title": "Donald Trump riding a pig!",
-			"description": "No this isn't fake news. Donald Trump is riding a pig somewhere on campus. Nearby tiles produce no food as the pig is eating it all. Energy and Ore production remains unaffected.",
+			"description": "No this isn't fake news. Donald Trump is riding a pig somewhere on campus. Nearby tiles produce no food. Energy and Ore production is unaffected.",
 			"duration": 4,
 			"numberOfTilesToAffect": 5,
 			"foodMultiplier": 0,
@@ -15,7 +15,7 @@
 		},
 		{
 			"title": "Meteor Strike!",
-			"description": "A meteor strike has hit several tiles. These tiles no longer produce food. However, ore production has increased 50% and energy production has increased 25%.",
+			"description": "A meteor strike has hit several tiles. These tiles no longer produce food, ore production has increased 50% & energy production has increased 25%.",
 			"duration": 5,
 			"numberOfTilesToAffect": 7,
 			"foodMultiplier": 0,
@@ -41,7 +41,7 @@
 		},
 		{
 			"title": "Attack of the Geese!",
-			"description": "The local wildlife is fighting back due to the recent construction work. Fortunately your Roboticons can hold them off, but any tiles without them will cease production of all resources.",
+			"description": "Geese are attacking tiles without Roboticons! Affected tiles produce nothing",
 			"duration": 5,
 			"numberOfTilesToAffect": 6,
 			"foodMultiplier": 0,
@@ -54,7 +54,7 @@
 		},
 		{
 			"title": "Prof. Colin Runciman appears!",
-			"description": "A tile has been graced by the presence of Prof. Colin Runciman and he has enhanced its Roboticon. This doubles the ore and food production, but at the cost of halving the energy production.",
+			"description": "A tile has been graced by the presence of Prof. Colin Runciman. Food and Ore production is doubled, energy halved, on affected tiles.",
 			"duration": 3,
 			"numberOfTilesToAffect": 1,
 			"foodMultiplier": 2,
@@ -67,7 +67,7 @@
 		},
 		{
 			"title": "Construction has begun!",
-			"description": "Another building site has been set up, surprise surprise... These tiles now produce no energy, but ore production has increased by 50%.",
+			"description": "Another building site! These tiles now produce no energy, but ore production has increased by 50%.",
 			"duration": 4,
 			"numberOfTilesToAffect": 4,
 			"foodMultiplier": 1,


### PR DESCRIPTION
Fixed a spelling mistake in randomevent
Shortened the length of the start of random event messages so they fit on the window
closes #92 #69 